### PR TITLE
Fix: Update PHP version in test workflow to 8.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           cache: 'yarn'
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
           extensions: mbstring, bcmath
       - id: composercache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/sass/components/_wysiwyg.scss
+++ b/sass/components/_wysiwyg.scss
@@ -60,8 +60,8 @@
 
   ul,
   ol {
-    padding: 0;
     clear: both;
+    padding: 0;
     list-style: none;
 
     li {


### PR DESCRIPTION
The previous PHP version (8.3) in the GitHub Actions workflow was causing a conflict with the project's `composer.json` file, which requires PHP 8.4.*.

This commit updates the workflow to use PHP 8.4, which should resolve the test failures related to PHP version incompatibility during `composer install`.